### PR TITLE
setup_auth_keys should only happen if proper auth params sent in. 

### DIFF
--- a/lib/chankura_api/client.rb
+++ b/lib/chankura_api/client.rb
@@ -8,7 +8,7 @@ module ChankuraAPI
 
     def initialize(options={})
       options = options.symbolize_keys
-      setup_auth_keys options
+      setup_auth_keys options if options[:access_key] && options[:secret_key]
       @endpoint = options[:endpoint] || 'https://trading.chankura.com'
       @timeout  = options[:timeout]  || 60
     end

--- a/test/chankura_api/test_client.rb
+++ b/test/chankura_api/test_client.rb
@@ -1,6 +1,11 @@
 require 'helper'
 
 class TestClient < Minitest::Test
+  def test_instantiation_without_keys
+    client = ChankuraAPI::Client.new
+    assert_equal client.class, ChankuraAPI::Client
+  end
+
   def test_access_private_apis_without_keys
     assert_raises ArgumentError do
       ChankuraAPI::Client.new.post ''


### PR DESCRIPTION
The Ruby gem should allow for the Chankura Public API.

Currently instantiation of the client forces the flow through setup_auth_keys method, which raises if there are not auth options sent in. 

This PR prevents the call to setup_auth_keys if the auth options are not sent in, which opens up the gem to be used with the public API once again. 

( Of course, if you guys prefer to keep the Ruby gem for private API use only, then an update to the README would be preferable. )